### PR TITLE
feat(zm): kill-feed round lock with .lock/.unlock, ADS+2 toggle, and min-round guard

### DIFF
--- a/Join-in-progress-script/PostRoundLock.gsc
+++ b/Join-in-progress-script/PostRoundLock.gsc
@@ -5,10 +5,25 @@
 
 init()
 {
+    // Config
+    level.min_lock_round = 20; // round at which the lock system becomes active
+
+    // State
+    level.locked = false;
+    level.pin = "";
+    level.lock_initialized = false;
+
+    // Reset dvars on script start
     SetDvar( "password", "" );
     SetDvar( "g_password", "" );
-    level thread SetPasswordsOnRound( 20 );
+
+    // Threads
     level thread onPlayerConnect();
+    level thread roundMonitor();
+
+    // Chat listeners at level scope (param order: text, player)
+    level thread listenForChatCommands();      // "say"
+    level thread listenForTeamChatCommands();  // "say_team"
 }
 
 onPlayerConnect()
@@ -16,65 +31,199 @@ onPlayerConnect()
     for ( ;; )
     {
         level waittill( "connected", player );
-        level.locked = false;
-        player thread monitorUnlockInput(player);
+
+        // ADS + 2 input toggle
+        player thread monitorUnlockInput();
     }
 }
 
-setPasswordsOnRound( roundNumber )
+// Round transitions -> announce state
+roundMonitor()
 {
     level endon( "disconnect" );
-    
-    while ( true ) 
+
+    for ( ;; )
     {
         level waittill( "between_round_over" );
-        if ( level.round_number >= roundNumber )
+
+        // First time we reach threshold -> auto-lock
+        if ( isRoundLockActive() && !level.lock_initialized )
         {
-            level.locked = true; // Set lock
-            pin = generateString();
-            setDvar( "g_password", pin );
-            level thread messageRepeat( "Server is now locked. Use password ^5" + pin + " ^7to rejoin. Or Unlock using ^5ADS + 2" );
-            break;
+            level.lock_initialized = true;
+            level.locked = true;
+            level.pin = generatePin();
+            SetDvar( "g_password", level.pin );
+            SetDvar( "password", level.pin );
+        }
+
+        if ( !level.lock_initialized )
+            continue;
+
+        if ( level.locked )
+        {
+            if ( !isDefined( level.pin ) || level.pin == "" )
+                level.pin = generatePin();
+
+            SetDvar( "g_password", level.pin );
+            SetDvar( "password", level.pin );
+
+            announceAll( getLockedMessage() );
+        }
+        else
+        {
+            SetDvar( "g_password", "" );
+            SetDvar( "password", "" );
+
+            announceAll( getUnlockedMessage() );
         }
     }
 }
 
-messageRepeat( message )
+// ADS + 2 to toggle
+monitorUnlockInput()
 {
-    level endon( "disconnect" );
-    
-    while ( true )
+    self endon( "disconnect" );
+
+    for ( ;; )
     {
-        iPrintLn( message );
-        level waittill( "between_round_over" );
+        if ( self adsbuttonpressed() && self ActionSlotTwoButtonPressed() )
+        {
+            setLocked( !level.locked, self );
+            wait( 0.4 ); // debounce
+        }
+        wait( 0.05 );
     }
 }
 
-generateString()
+// Level-scope chat listener: global chat
+listenForChatCommands()
 {
-    str = "";
+    level endon( "disconnect" );
 
-    for ( i = 0; i < 4; i++ )
+    for ( ;; )
     {
-        str = str + randomInt( 10 );
+        level waittill( "say", text, player );
+
+        if ( !isDefined( text ) || !isDefined( player ) )
+            continue;
+
+        if ( text == ".unlock" )
+        {
+            setLocked( false, player );
+        }
+        else if ( text == ".lock" )
+        {
+            setLocked( true, player );
+        }
+    }
+}
+
+// Level-scope chat listener: team chat
+listenForTeamChatCommands()
+{
+    level endon( "disconnect" );
+
+    for ( ;; )
+    {
+        level waittill( "say_team", text, player );
+
+        if ( !isDefined( text ) || !isDefined( player ) )
+            continue;
+
+        if ( text == ".unlock" )
+        {
+            setLocked( false, player );
+        }
+        else if ( text == ".lock" )
+        {
+            setLocked( true, player );
+        }
+    }
+}
+
+// Set lock state and announce via kill feed.
+// actor: optional player who triggered the change.
+setLocked( shouldLock, actor )
+{
+    actorName = getActorName( actor );
+
+    // Block locking until the minimum round is reached
+    if ( shouldLock && !isRoundLockActive() )
+    {
+        if ( isDefined( actor ) )
+            actor iPrintLn( "^3Locking is disabled until round ^5" + level.min_lock_round );
+        return;
     }
 
+    if ( shouldLock )
+    {
+        level.lock_initialized = true;
+        level.locked = true;
+        level.pin = generatePin();
+
+        SetDvar( "g_password", level.pin );
+        SetDvar( "password", level.pin );
+
+        announceAll( actorName + " ^7locked the server. Password ^5" + level.pin );
+    }
+    else
+    {
+        level.locked = false;
+
+        SetDvar( "g_password", "" );
+        SetDvar( "password", "" );
+
+        announceAll( actorName + " ^7unlocked the server." );
+    }
+}
+
+// Helpers
+
+isRoundLockActive()
+{
+    return isDefined( level.round_number ) && level.round_number >= level.min_lock_round;
+}
+
+getLockedMessage()
+{
+    return "Server is now ^1LOCKED^7. Use password ^5" + level.pin + " ^7to rejoin. Unlock with ^5ADS + 2^7 or type ^5.unlock^7";
+}
+
+getUnlockedMessage()
+{
+    return "Server remains ^2unlocked^7 - to lock again do ^5.lock^7 (or press ^5ADS + 2^7)";
+}
+
+// Broadcast to all players via kill feed
+announceAll( message )
+{
+    players = getPlayersSafe();
+    for ( i = 0; i < players.size; i++ )
+        players[i] iPrintLn( message );
+}
+
+// Safe actor name
+getActorName( actor )
+{
+    if ( isDefined( actor ) && isDefined( actor.name ) )
+        return actor.name;
+    return "Someone";
+}
+
+// 4-digit PIN
+generatePin()
+{
+    str = "";
+    for ( i = 0; i < 4; i++ )
+        str = str + randomInt( 10 );
     return str;
 }
 
-monitorUnlockInput(player)
+// Safe players array getter
+getPlayersSafe()
 {
-    player endon( "disconnect" );
-    
-    while ( true )
-    {
-        if ( level.locked && player adsbuttonpressed() && player ActionSlotTwoButtonPressed() )
-        {
-            level.locked = false; 
-            player iPrintLn( "Lock removed. Server is now unlocked." );
-            setDvar( "g_password", "" );
-        }
-        wait ( 0.1 );
-    }
-}
+    if ( isDefined( level.players ) )
+        return level.players;
 
+    return getEntArray( "player", "classname" );
+}

--- a/Join-in-progress-script/README.md
+++ b/Join-in-progress-script/README.md
@@ -2,4 +2,4 @@ Script for stopping players joining a zombies lobby after round 20
 
 * Added unlock feature!
 
-Big thanks to NotHGM, Resxt and Ayymoss <33
+Big thanks to [HGM](https://github.com/NotHGM), [Resxt](https://github.com/Resxt) and [Amos](https://github.com/Ayymoss) <33


### PR DESCRIPTION
Adds a kill-feed-only round-lock system for Plutonium T6 Zombies:
- Chat commands: .lock / .unlock, plus ADS + 2 toggle
- Auto-lock at configurable minimum round (default: 20)
- Prevents locking before the minimum round; .unlock always allowed
- Per-round status messages (locked shows PIN, unlocked shows hint)
- Action announcements include player name; new PIN generated on each lock
- Properly updates g_password/password dvars